### PR TITLE
Multiple data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,28 @@ gems:
 
 ## Usage
 
-TODO: Write usage instructions here
+You need to configure Jekyll so it knows which data to use. In your `_config.yml` add the following to tell jekyll-everypolitician where to get the data from:
+
+```yaml
+everypolitician:
+  sources:
+    - https://github.com/everypolitician/everypolitician-data/raw/master/data/Australia/Representatives/ep-popolo-v1.0.json
+```
+
+This tells it to use the data for the Australian Representatives, and specifies which version of the data to use, in this case `master`.
+
+When sources is an array, as in the example above, the collections that are created are `people`, `organizations`, `areas` and `events`.
+
+Sometimes you'll want more than one source, for example you might want the upper house as well. For this case you can specify sources as a hash:
+
+```yaml
+everypolitician:
+  sources:
+    assembly: https://github.com/everypolitician/everypolitician-data/raw/master/data/Australia/Representatives/ep-popolo-v1.0.json
+    senate: https://github.com/everypolitician/everypolitician-data/raw/master/data/Australia/Senate/ep-popolo-v1.0.json
+```
+
+When `sources` is a hash like this the collections that are created are prefixed with the key of the hash, e.g. `assembly_people`, `senate_people`, `assembly_areas` etc.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ everypolitician:
 
 When `sources` is a hash like this the collections that are created are prefixed with the key of the hash, e.g. `assembly_people`, `senate_people`, `assembly_areas` etc.
 
+### Layouts
+
+This plugin will try and use layouts that are named after the generated collections. So in the examples above if you'd specified `sources` as an array then it would try to use `_layouts/people.html` as the layout for the `people` collection. Similarly if you specify `sources` as a hash then it would try to use something like `_layouts/assembly_people.html` for the `assembly_people` collection.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/jekyll/everypolitician.rb
+++ b/lib/jekyll/everypolitician.rb
@@ -23,9 +23,11 @@ module Jekyll
             doc.merge_data!(item)
             doc.merge_data!(
               'title' => item['name'],
-              'layout' => collection_name,
               'memberships' => memberships_for(item, collection_name, memberships)
             )
+            if site.layouts.key?(collection_name)
+              doc.merge_data!('layout' => collection_name)
+            end
             collection.docs << doc
           end
           site.collections[collection_name] = collection

--- a/lib/jekyll/everypolitician.rb
+++ b/lib/jekyll/everypolitician.rb
@@ -11,6 +11,7 @@ module Jekyll
   module Everypolitician
     class Generator < Jekyll::Generator
       def generate(site)
+        return unless site.config.key?('everypolitician')
         popolo = JSON.parse(open(site.config['everypolitician']['sources'].first).read)
         memberships = popolo['memberships']
         popolo.keys.each do |collection_name|

--- a/lib/jekyll/everypolitician.rb
+++ b/lib/jekyll/everypolitician.rb
@@ -11,7 +11,7 @@ module Jekyll
   module Everypolitician
     class Generator < Jekyll::Generator
       def generate(site)
-        popolo = JSON.parse(open(site.config['everypolitician_url']).read)
+        popolo = JSON.parse(open(site.config['everypolitician']['sources'].first).read)
         memberships = popolo['memberships']
         popolo.keys.each do |collection_name|
           next unless popolo[collection_name].is_a?(Array)

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -18,7 +18,7 @@ class Jekyll::EverypoliticianTest < Minitest::Test
 
   def test_it_creates_collections_from_popolo
     generate_with_single_source
-    assert_equal 50, site.collections['persons'].docs.size
+    assert_equal 50, site.collections['people'].docs.size
     assert_equal 16, site.collections['organizations'].docs.size
     assert_equal 3, site.collections['events'].docs.size
     assert_equal 0, site.collections['areas'].docs.size
@@ -26,19 +26,19 @@ class Jekyll::EverypoliticianTest < Minitest::Test
 
   def test_it_uses_default_layout
     generate_with_single_source
-    person = site.collections['persons'].docs.first
+    person = site.collections['people'].docs.first
     assert_nil person.data['layout']
   end
 
   def test_collection_name_layout_used_if_available
-    site.layouts['persons'] = Jekyll::Layout.new(site, 'persons.html', '_layouts')
+    site.layouts['people'] = Jekyll::Layout.new(site, 'people.html', '_layouts')
     generate_with_single_source
-    person = site.collections['persons'].docs.first
-    assert_equal 'persons', person.data['layout']
+    person = site.collections['people'].docs.first
+    assert_equal 'people', person.data['layout']
   end
 
   def test_missing_configuration
     Jekyll::Everypolitician::Generator.new(site.config).generate(site)
-    assert_nil site.collections['persons']
+    assert_nil site.collections['people']
   end
 end

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -2,13 +2,7 @@ require 'test_helper'
 
 class Jekyll::EverypoliticianTest < Minitest::Test
   def site
-    @site ||= Jekyll::Site.new(Jekyll.configuration).tap do |s|
-      s.config['everypolitician_url'] = 'test/fixtures/ep-popolo-v1.0.json'
-    end
-  end
-
-  def setup
-    Jekyll::Everypolitician::Generator.new.generate(site)
+    @site ||= Jekyll::Site.new(Jekyll.configuration)
   end
 
   def test_that_it_has_a_version_number
@@ -16,9 +10,26 @@ class Jekyll::EverypoliticianTest < Minitest::Test
   end
 
   def test_it_creates_collections_from_popolo
+    site.config['everypolitician_url'] = 'test/fixtures/ep-popolo-v1.0.json'
+    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
     assert_equal 50, site.collections['persons'].docs.size
     assert_equal 16, site.collections['organizations'].docs.size
     assert_equal 3, site.collections['events'].docs.size
     assert_equal 0, site.collections['areas'].docs.size
+  end
+
+  def test_it_uses_default_layout
+    site.config['everypolitician_url'] = 'test/fixtures/ep-popolo-v1.0.json'
+    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    person = site.collections['persons'].docs.first
+    assert_nil person.data['layout']
+  end
+
+  def test_collection_name_layout_used_if_available
+    site.config['everypolitician_url'] = 'test/fixtures/ep-popolo-v1.0.json'
+    site.layouts['persons'] = Jekyll::Layout.new(site, 'persons.html', '_layouts')
+    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    person = site.collections['persons'].docs.first
+    assert_equal 'persons', person.data['layout']
   end
 end

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -9,9 +9,15 @@ class Jekyll::EverypoliticianTest < Minitest::Test
     refute_nil ::Jekyll::Everypolitician::VERSION
   end
 
-  def test_it_creates_collections_from_popolo
-    site.config['everypolitician_url'] = 'test/fixtures/ep-popolo-v1.0.json'
+  def generate_with_single_source
+    site.config['everypolitician'] = {
+      'sources' => ['test/fixtures/ep-popolo-v1.0.json']
+    }
     Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+  end
+
+  def test_it_creates_collections_from_popolo
+    generate_with_single_source
     assert_equal 50, site.collections['persons'].docs.size
     assert_equal 16, site.collections['organizations'].docs.size
     assert_equal 3, site.collections['events'].docs.size
@@ -19,16 +25,14 @@ class Jekyll::EverypoliticianTest < Minitest::Test
   end
 
   def test_it_uses_default_layout
-    site.config['everypolitician_url'] = 'test/fixtures/ep-popolo-v1.0.json'
-    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    generate_with_single_source
     person = site.collections['persons'].docs.first
     assert_nil person.data['layout']
   end
 
   def test_collection_name_layout_used_if_available
-    site.config['everypolitician_url'] = 'test/fixtures/ep-popolo-v1.0.json'
     site.layouts['persons'] = Jekyll::Layout.new(site, 'persons.html', '_layouts')
-    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    generate_with_single_source
     person = site.collections['persons'].docs.first
     assert_equal 'persons', person.data['layout']
   end

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -36,4 +36,9 @@ class Jekyll::EverypoliticianTest < Minitest::Test
     person = site.collections['persons'].docs.first
     assert_equal 'persons', person.data['layout']
   end
+
+  def test_missing_configuration
+    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    assert_nil site.collections['persons']
+  end
 end

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -16,6 +16,15 @@ class Jekyll::EverypoliticianTest < Minitest::Test
     Jekyll::Everypolitician::Generator.new(site.config).generate(site)
   end
 
+  def generate_with_source_hash
+    site.config['everypolitician'] = {
+      'sources' => {
+        'assembly' => 'test/fixtures/ep-popolo-v1.0.json'
+      }
+    }
+    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+  end
+
   def test_it_creates_collections_from_popolo
     generate_with_single_source
     assert_equal 50, site.collections['people'].docs.size
@@ -40,5 +49,13 @@ class Jekyll::EverypoliticianTest < Minitest::Test
   def test_missing_configuration
     Jekyll::Everypolitician::Generator.new(site.config).generate(site)
     assert_nil site.collections['people']
+  end
+
+  def test_sources_hash
+    generate_with_source_hash
+    assert_equal 50, site.collections['assembly_people'].docs.size
+    assert_equal 16, site.collections['assembly_organizations'].docs.size
+    assert_equal 3, site.collections['assembly_events'].docs.size
+    assert_equal 0, site.collections['assembly_areas'].docs.size
   end
 end


### PR DESCRIPTION
Allow people to pull data from multiple different sources. This needs to be configurable so that we can distinguish between the different houses, for example.

``` yaml
everypolitician:
  sources:
    assembly: assembly-ep-popolo-v1.0.json
    senate: senate-ep-popolo-v1.0.json
```

This will then generate collections that are prefixed with the key of the source.

``` liquid
{% for person in site.assembly_people %}
  <h1>{{ person.name }}</h1>
  <!-- etc -->
{% endfor %}
```

Closes #3 
Closes #2 
