### PR TITLE
Make the Generator high priority

### DIFF
--- a/lib/jekyll/everypolitician.rb
+++ b/lib/jekyll/everypolitician.rb
@@ -14,6 +14,8 @@ module Jekyll
         'persons' => 'people'
       }
 
+      priority :high
+
       def generate(site)
         return unless site.config.key?('everypolitician')
         sources = site.config['everypolitician']['sources']

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -80,4 +80,8 @@ class Jekyll::EverypoliticianTest < Minitest::Test
     assert_equal person['id'], membership['person_id']
     assert_equal person, membership['person']
   end
+
+  def test_generator_has_high_priority
+    assert_equal :high, Jekyll::Everypolitician::Generator.priority
+  end
 end


### PR DESCRIPTION
This means that it will get run earlier in the build process. That means
that other plugins that depend on the data it adds to the site object
don't have to explicitly declare a priority as they will automatically
be normal priority.
