### PR TITLE
Fallback to collection name for layout

### DIFF
--- a/lib/jekyll/everypolitician.rb
+++ b/lib/jekyll/everypolitician.rb
@@ -46,6 +46,8 @@ module Jekyll
             )
             if site.layouts.key?(collection_name)
               doc.merge_data!('layout' => collection_name)
+            elsif site.layouts.key?(collection_name_for(type))
+              doc.merge_data!('layout' => collection_name_for(type))
             end
             collection.docs << doc
           end

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -84,4 +84,11 @@ class Jekyll::EverypoliticianTest < Minitest::Test
   def test_generator_has_high_priority
     assert_equal :high, Jekyll::Everypolitician::Generator.priority
   end
+
+  def test_falls_back_to_collection_name_layout
+    site.layouts['people'] = Jekyll::Layout.new(site, 'people.html', '_layouts')
+    generate_with_source_hash
+    person = site.collections['assembly_people'].docs.first
+    assert_equal 'people', person.data['layout']
+  end
 end


### PR DESCRIPTION
If you've specified that you want data from multiple sources then you
previously had to specify a separate template for each one, e.g. an
`assembly_people.html` layout. This change means that it will fallback to
trying to use a `people.html` template, so you don't have to create lots
of duplicate layouts.
