### PR TITLE
Remove activesupport dependency

### DIFF
--- a/jekyll-everypolitician.gemspec
+++ b/jekyll-everypolitician.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 4'
   spec.add_dependency 'jekyll', '>= 3'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/lib/jekyll/everypolitician.rb
+++ b/lib/jekyll/everypolitician.rb
@@ -4,8 +4,6 @@ require 'json'
 require 'open-uri'
 
 require 'jekyll'
-require 'active_support'
-require 'active_support/core_ext/string'
 
 module Jekyll
   module Everypolitician
@@ -37,7 +35,7 @@ module Jekyll
           collection = Collection.new(site, collection_name)
           popolo[type].each do |item|
             next unless item['id']
-            path = File.join(site.source, "_#{collection_name}", "#{item['id'].parameterize}.md")
+            path = File.join(site.source, "_#{collection_name}", "#{Jekyll::Utils.slugify(item['id'])}.md")
             doc = Document.new(path, collection: collection, site: site)
             doc.merge_data!(item)
             doc.merge_data!(


### PR DESCRIPTION
Jekyll comes with support for creating slugs from strings, so use that
rather than depending on activesupport.
