### PR TITLE
Make sure data exists before generators are run

### DIFF
--- a/lib/jekyll/everypolitician.rb
+++ b/lib/jekyll/everypolitician.rb
@@ -7,14 +7,18 @@ require 'jekyll'
 
 module Jekyll
   module Everypolitician
-    class Generator < Jekyll::Generator
+    class PopoloFetcher
       COLLECTION_MAPPING = {
         'persons' => 'people'
       }
 
-      priority :high
+      attr_reader :site
 
-      def generate(site)
+      def initialize(site)
+        @site = site
+      end
+
+      def read!
         return unless site.config.key?('everypolitician')
         sources = site.config['everypolitician']['sources']
         if sources.is_a?(Array)
@@ -89,4 +93,8 @@ module Jekyll
       end
     end
   end
+end
+
+Jekyll::Hooks.register :site, :post_read do |site|
+  Jekyll::Everypolitician::PopoloFetcher.new(site).read!
 end

--- a/test/jekyll/everypolitician_test.rb
+++ b/test/jekyll/everypolitician_test.rb
@@ -13,7 +13,7 @@ class Jekyll::EverypoliticianTest < Minitest::Test
     site.config['everypolitician'] = {
       'sources' => ['test/fixtures/ep-popolo-v1.0.json']
     }
-    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    Jekyll::Everypolitician::PopoloFetcher.new(site).read!
   end
 
   def generate_with_source_hash
@@ -22,7 +22,7 @@ class Jekyll::EverypoliticianTest < Minitest::Test
         'assembly' => 'test/fixtures/ep-popolo-v1.0.json'
       }
     }
-    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    Jekyll::Everypolitician::PopoloFetcher.new(site).read!
   end
 
   def test_it_creates_collections_from_popolo
@@ -47,7 +47,7 @@ class Jekyll::EverypoliticianTest < Minitest::Test
   end
 
   def test_missing_configuration
-    Jekyll::Everypolitician::Generator.new(site.config).generate(site)
+    Jekyll::Everypolitician::PopoloFetcher.new(site).read!
     assert_nil site.collections['people']
   end
 
@@ -79,10 +79,6 @@ class Jekyll::EverypoliticianTest < Minitest::Test
     membership = person['memberships'].first
     assert_equal person['id'], membership['person_id']
     assert_equal person, membership['person']
-  end
-
-  def test_generator_has_high_priority
-    assert_equal :high, Jekyll::Everypolitician::Generator.priority
   end
 
   def test_falls_back_to_collection_name_layout


### PR DESCRIPTION
By using Jekyll hooks instead of a generator we can ensure that the data
pulled from EveryPolitician has been placed into collections before any
of the generators run.

This seems more "correct" as it uses a ':post_read' hook, which gets run
just after all the other pages, posts and collections have been read
from the disk.
